### PR TITLE
fix: config nodes require `node-config-input-{variable}`

### DIFF
--- a/utils/templates/config/node-type.html/editor.html.mustache
+++ b/utils/templates/config/node-type.html/editor.html.mustache
@@ -1,6 +1,6 @@
 <script type="text/html" data-template-name="<%NodeTypeKebabCase%>">
   <div class="form-row">
-    <label for="node-input-name"><i class="icon-tag"></i> Name</label>
-    <input type="text" id="node-input-name" placeholder="Name">
+    <label for="node-config-input-name"><i class="icon-tag"></i> Name</label>
+    <input type="text" id="node-config-input-name" placeholder="Name">
   </div>
 </script>


### PR DESCRIPTION
The current config node template is valid for a normal node. This issue leads to the config node not being able to preserve its state.

This fix adds the "-config-" in the middle, allowing the config node to preserve it's state and function correctly.